### PR TITLE
feat(codecompanion): Allow specifying adapter for chat sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ NOTE: aibou (相棒) means "partner" in Japanese.
 }
 ```
 
+## Configuration
+
+aibou.nvim provides several configuration options:
+
+```lua
+require("aibou.codecompanion").start({
+    -- Customize the system prompt for the AI assistant
+    system_prompt = "You are a programming expert. Please provide advice on code.",
+    
+    -- Customize the initial user prompt when starting the conversation
+    user_prompt = "Lets start pair programming",
+    
+    -- Specify which adapter to use with CodeCompanion
+    -- If nil (default), the CodeCompanion's configured adapter will be used
+    adapter = "openai", -- can also be "anthropic", "ollama", etc.
+})
+```
+
 ## Demo
 
 <div><video controls src="https://github.com/user-attachments/assets/cfbd7ff8-051b-4815-85a0-027ad64bcbd4" muted="false"></video></div>

--- a/lua/aibou/config.lua
+++ b/lua/aibou/config.lua
@@ -10,6 +10,7 @@ config = {
 		"Sometimes I'll share stuff that's not a diff, so just think about whether to look at the whole file or focus on a diff, or series of diffs. you got this! 🤔 Thanks a bunch! 🙏",
 	}, "\n"),
 	user_prompt = "Lets start pair programming",
+	adapter = nil,
 }
 
 return config


### PR DESCRIPTION
feat(codecompanion): Allow specifying adapter per chat session

Adds configuration options to the table passed to `require("aibou.codecompanion").start()` for specifying the `adapter` for a new chat session.

This enhancement provides greater flexibility when initiating CodeCompanion sessions. A key motivation is to better support integrations like the "aibou" plugin, where CodeCompanion might be used for numerous, iterative interactions (like sending code diffs repeatedly).

This change enables users to:

* **Select adapter per session:** Choose a specific CodeCompanion adapter (e.g., "openai", "anthropic", "ollama", or a custom one) for the upcoming chat session, overriding the default adapter configured globally by the user.
* **Optimize adapter choice for specific integrations (e.g., aibou):** Define and select adapters tailored to the specific needs of how integrations use CodeCompanion. For example, plugins like "aibou" enable an iterative workflow involving multiple interactions with CodeCompanion. This feature allows users to configure and choose a dedicated adapter (perhaps utilizing a more cost-effective model) specifically for this type of workflow. This provides flexibility, allowing users to reserve their primary global adapter, potentially configured with a different model (e.g., a more powerful one), for other tasks.

These session-specific settings are temporary. The adapter setting reverts to the user's globally configured adapter when the chat buffer is closed or wiped out (`BufWipeout`).

**Example Usage:**

```lua
-- Example: Using a cost-effective adapter specifically configured for Aibou
require("aibou.codecompanion").start({
  adapter = "aibou_low_cost_model",
})
```

```lua
-- Example: codecompanion adapter settings
require("codecompanion").setup({
  adapters = {
    aibou_low_cost_model = function()
      return require("codecompanion.adapters").extend("gemini", {
        schema = {
          model = {
            default = "gemini-2.5-flash-preview-04-17",
          },
        },
      })
    end,
  },
})
```