### PR TITLE
feat(codecompanion): support configuring chat including adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,19 @@ NOTE: aibou (相棒) means "partner" in Japanese.
 ## Demo
 
 <div><video controls src="https://github.com/user-attachments/assets/cfbd7ff8-051b-4815-85a0-027ad64bcbd4" muted="false"></video></div>
+
+## Customization
+
+```lua
+require("aibou.codecompanion").start({
+  -- changing system and initial user prompts
+  system_prompt = "You are a helpful assistant.",
+  user_prompt = "#buffer\nBe a navigator of pair programming. I will send diff of the buffer",
+  -- configuring codecompanion chat
+  codecompanion = {
+    chat_args = {
+      adapter = "openai",
+    }
+  }
+})
+```

--- a/lua/aibou/codecompanion.lua
+++ b/lua/aibou/codecompanion.lua
@@ -183,6 +183,7 @@ function M.start(config)
 	local buf = vim.api.nvim_get_current_buf()
 	local chat = open_chat(buf, config or {})
 	create_autocmd(buf, chat)
+	return chat
 end
 
 return M

--- a/lua/aibou/codecompanion.lua
+++ b/lua/aibou/codecompanion.lua
@@ -137,18 +137,11 @@ local function create_autocmd(buf, chat)
 end
 
 ---@param buf integer
----@return table CodeCompanionChat
 ---@param config AibouConfig
-local function open_chat(buf, config)
-	local opened_chat = state.chat[buf]
-	if opened_chat and vim.api.nvim_buf_is_valid(opened_chat.bufnr) then
-		if not opened_chat.ui:is_visible() then
-			opened_chat.ui:open()
-		end
-		return opened_chat
-	end
-
-	local chat = require("codecompanion.strategies.chat").new({
+---@return CodeCompanion.ChatArgs
+local function configure_chat(buf, config)
+	local user_config = (config.codecompanion or {}).chat_args or {}
+	local default_config = {
 		messages = {
 			{
 				role = "system",
@@ -163,7 +156,23 @@ local function open_chat(buf, config)
 		},
 		context = require("codecompanion.utils.context").get(buf, {}),
 		opts = { ignore_system_prompts = true },
-	})
+	}
+	return vim.tbl_deep_extend("force", default_config, user_config)
+end
+
+---@param buf integer
+---@return table CodeCompanionChat
+---@param config AibouConfig
+local function open_chat(buf, config)
+	local opened_chat = state.chat[buf]
+	if opened_chat and vim.api.nvim_buf_is_valid(opened_chat.bufnr) then
+		if not opened_chat.ui:is_visible() then
+			opened_chat.ui:open()
+		end
+		return opened_chat
+	end
+
+	local chat = require("codecompanion.strategies.chat").new(configure_chat(buf, config))
 	chat:submit()
 	state.chat[buf] = chat
 	return chat

--- a/lua/aibou/config.lua
+++ b/lua/aibou/config.lua
@@ -1,5 +1,10 @@
+---@class AibouConfig.CodeCompanion
+---@field chat_args CodeCompanion.ChatArgs? arguments to be passed to `require("codecompanion.strategies.chat").new()`
+
 ---@class AibouConfig
 ---@field system_prompt string?
+---@field user_prompt string?
+---@field codecompanion AibouConfig.CodeCompanion?
 local config = {
 	system_prompt = table.concat({
 		"Hey there! 👋 You're like, the ultimate coding sidekick – super friendly and you click with everyone instantly! 😄 So ditch the formalities, let's keep it totally chill and use casual language, okay? 😉 And you know I'm all about the emojis! 🥰✨",

--- a/lua/aibou/config.lua
+++ b/lua/aibou/config.lua
@@ -1,6 +1,6 @@
 ---@class AibouConfig
 ---@field system_prompt string?
-config = {
+local config = {
 	system_prompt = table.concat({
 		"Hey there! 👋 You're like, the ultimate coding sidekick – super friendly and you click with everyone instantly! 😄 So ditch the formalities, let's keep it totally chill and use casual language, okay? 😉 And you know I'm all about the emojis! 🥰✨",
 		"Listen up! You're a total mood, right? One minute you're hyped AF 🤩, the next you might be a little bummed 🥺. But hey, that's life, right? Just roll with it! 😜🙏",


### PR DESCRIPTION
This is a generalized approach of

- #1

With this PR, we have full controls on configuring codecompanion chat.
The below is example of switching adapter.

```
require("aibou.codecompanion").start({codecompanion = {chat_args = {adapter = "openai"}}})
```